### PR TITLE
Makes get_data_between an exclusive range

### DIFF
--- a/flask_monitoringdashboard/database/function_calls.py
+++ b/flask_monitoringdashboard/database/function_calls.py
@@ -81,7 +81,7 @@ def get_data_between(time_from, time_to=None):
     with session_scope() as db_session:
         result = db_session.query(FunctionCall).filter(FunctionCall.time >= time_from)
         if time_to:
-            result = result.filter(FunctionCall.time <= time_to)
+            result = result.filter(FunctionCall.time < time_to)
         result = result.all()
         db_session.expunge_all()
         return result


### PR DESCRIPTION
Ensures the time period passed to get_data_between is exclusive, such that we can be sure an EndpointCall is not fetched twice.