### PR TITLE
Fallback to default UTC timezone when no system timezone is found

### DIFF
--- a/flask_monitoringdashboard/core/config/__init__.py
+++ b/flask_monitoringdashboard/core/config/__init__.py
@@ -43,7 +43,11 @@ class Config(object):
 
         # visualization
         self.colors = {}
-        self.timezone = pytz.timezone(str(get_localzone()))
+        try:
+            default_timezone = pytz.timezone(str(get_localzone()))
+        except pytz.UnknownTimeZoneError:
+            default_timezone = pytz.timezone('UTC')
+        self.timezone = default_timezone
 
         # define a custom function to retrieve the session_id or username
         self.group_by = None
@@ -100,7 +104,7 @@ class Config(object):
             file = os.getenv(envvar)
             if log_verbose:
                 log("Running with config from: " + (str(file)))
-                
+
         if not file:
             # Travis does not need a config file.
             if '/home/travis/build/' in os.getcwd():
@@ -134,7 +138,7 @@ class Config(object):
             # visualization
             self.colors = parse_literal(parser, 'visualization', 'COLORS', self.colors)
             self.timezone = pytz.timezone(parse_string(parser, 'visualization', 'TIMEZONE', self.timezone.zone))
-            
+
             if log_verbose:
                 log("version: " + self.version)
                 log("username: " + self.username)

--- a/flask_monitoringdashboard/core/config/__init__.py
+++ b/flask_monitoringdashboard/core/config/__init__.py
@@ -44,10 +44,10 @@ class Config(object):
         # visualization
         self.colors = {}
         try:
-            default_timezone = pytz.timezone(str(get_localzone()))
+            self.timezone = pytz.timezone(str(get_localzone()))
         except pytz.UnknownTimeZoneError:
-            default_timezone = pytz.timezone('UTC')
-        self.timezone = default_timezone
+            log('Using default timezone, which is UTC')
+            self.timezone = pytz.timezone('UTC')
 
         # define a custom function to retrieve the session_id or username
         self.group_by = None


### PR DESCRIPTION
Heya 👋 

I tried setting up the dashboard on an app running in a Docker container. This caused an import failure because the timezone could not be loaded. This PR should handle the __init__ logic a bit more gracefully :) allow me to declare a timezone in the config file.

### How to test
- Setup a local environment without any resolvement methods in [unix](https://github.com/regebro/tzlocal/blob/master/tzlocal/unix.py#L39) or [windows](https://github.com/regebro/tzlocal/blob/master/tzlocal/win32.py#L89). Mounting this app in an Alpine container is a good example :)
- import the package
- Acknowledge crash with `pytz.exceptions.UnknownTimeZoneError: 'local'`
- Checkout PR
- Retry importing
- Acknowledge the import now works 🎉 

### Notes
I see the argument that you should configure your system properly. I'd  love to hear your thoughts on this in any case :)