### PR TITLE
fix request set down

### DIFF
--- a/flask_monitoringdashboard/database/request.py
+++ b/flask_monitoringdashboard/database/request.py
@@ -57,6 +57,7 @@ def add_request(db_session, duration, endpoint_id, ip, group_by, status_code):
     )
     db_session.add(request)
     db_session.flush()
+    db_session.commit()
     return request.id
 
 

--- a/flask_monitoringdashboard/database/request.py
+++ b/flask_monitoringdashboard/database/request.py
@@ -56,7 +56,6 @@ def add_request(db_session, duration, endpoint_id, ip, group_by, status_code):
         status_code=status_code,
     )
     db_session.add(request)
-    db_session.flush()
     db_session.commit()
     return request.id
 


### PR DESCRIPTION
I think the Outlier table is trying to update before the Request table is updated. The Outlier table has a foreign key that's linked to a primary key in the Request table, so by the time the Outlier table is updated, the corresponding record in the Request table does not exist. 

Should we commit our changes to the Request table right after the flush?