### PR TITLE
Fixed visualisation error in violin plot

### DIFF
--- a/flask_monitoringdashboard/static/js/controllers/reporting.js
+++ b/flask_monitoringdashboard/static/js/controllers/reporting.js
@@ -84,6 +84,9 @@ function ReportingController($scope, $http, $location, DTOptionsBuilder, menuSer
             xaxis: {
                 title: 'Execution time (ms)',
             },
+            yaxis: {
+                rangemode: "nonnegative"
+            }
         });
     };
 


### PR DESCRIPTION
In #278 it was mentioned that it looks like there are negative response times in the charts of the reports. This is not the case. It's merely a visualisation artifact.

This PR fixes that:

![image](https://user-images.githubusercontent.com/9981548/78257137-bf193380-74f9-11ea-9e49-4217c62de80e.png)
