### PR TITLE
Display arbitrarily small durations in the overview page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,5 @@ ENV/
 # own scripts
 flask_monitoringdashboard/make_requests.py
 flask_monitoringdashboard/session_test.py
-frontend/node_modules/
+flask_monitoringdashboard/frontend/node_modules/
 frontend/build/

--- a/flask_monitoringdashboard/frontend/js/filters.js
+++ b/flask_monitoringdashboard/frontend/js/filters.js
@@ -2,7 +2,17 @@ export function applyFilters(app) {
 
     app.filter('duration_ms', function () {
         return function (time) {
-            return Math.round(parseFloat(time) * 10) / 10;
+            const t = parseFloat(time);
+            // only show 0 for actual 0 values
+            if (t === 0){
+                return t
+            }
+            // calculate how many decimals to show for really small numbers
+            let decimalsPow10 = 10;
+            while (Math.round(t * decimalsPow10) === 0) {
+                decimalsPow10 *= 10;
+            }
+            return Math.round(t * decimalsPow10) / decimalsPow10;
         }
     });
 


### PR DESCRIPTION
Implement a visualization fix for #296 
![image](https://user-images.githubusercontent.com/7281856/94112425-b91b6400-fe45-11ea-908a-add5dc90ec81.png)
