### PR TITLE
Outlier isn't working with the stacktrace profiler

### DIFF
--- a/flask_monitoringdashboard/core/profiler/outlier_profiler.py
+++ b/flask_monitoringdashboard/core/profiler/outlier_profiler.py
@@ -82,14 +82,13 @@ class OutlierProfiler(threading.Thread):
     def stop_by_profiler(self):
         self._exit.set()
 
-    def add_outlier(self, request_id):
+    def add_outlier(self, session, request_id):
         if self._memory:
-            with session_scope() as session:
-                add_outlier(
-                    session,
-                    request_id,
-                    self._cpu_percent,
-                    self._memory,
-                    self._stacktrace,
-                    self._request,
-                )
+            add_outlier(
+                session,
+                request_id,
+                self._cpu_percent,
+                self._memory,
+                self._stacktrace,
+                self._request,
+            )

--- a/flask_monitoringdashboard/core/profiler/stacktrace_profiler.py
+++ b/flask_monitoringdashboard/core/profiler/stacktrace_profiler.py
@@ -100,7 +100,7 @@ class StacktraceProfiler(threading.Thread):
             self._lines_body = order_histogram(self._histogram.items())
             self.insert_lines_db(session, request_id)
             if self._outlier_profiler:
-                self._outlier_profiler.add_outlier(request_id)
+                self._outlier_profiler.add_outlier(session, request_id)
 
     def insert_lines_db(self, session, request_id):
         position = 0


### PR DESCRIPTION
I've received an email that outliers are not captured when the monitoring-level is set to 3. This is due to being twice in a `session_scope()`-context. This PR will fix the code