### PR TITLE
Support for Custom `get_ip` Injection

### DIFF
--- a/flask_monitoringdashboard/core/config/__init__.py
+++ b/flask_monitoringdashboard/core/config/__init__.py
@@ -60,7 +60,7 @@ class Config(object):
         # dependencies
         self.get_ip = None
 
-    def inject_dependencies(self, get_ip=None, url_for=None):
+    def inject_dependencies(self, get_ip=None):
         """
             Injects certain dependencies into the Monitoring Dashboard for better integration.
             :param get_ip: a function that gets the appropriate client IP address inside a request

--- a/flask_monitoringdashboard/core/config/__init__.py
+++ b/flask_monitoringdashboard/core/config/__init__.py
@@ -57,6 +57,19 @@ class Config(object):
         # store the Flask app
         self.app = None
 
+        # dependencies
+        self.get_ip = None
+
+    def inject_dependencies(self, get_ip=None, url_for=None):
+        """
+            Injects certain dependencies into the Monitoring Dashboard for better integration.
+            :param get_ip: a function that gets the appropriate client IP address inside a request
+                context. Overriding this allows you to provide the correct IP for logging purposes
+                in case your setup is running behind reverse proxies.
+        """
+        if get_ip:
+            self.get_ip = get_ip
+
     def init_from(self, file=None, envvar=None, log_verbose=False):
         """
             The config_file must at least contains the following variables in section 'dashboard':

--- a/flask_monitoringdashboard/core/get_ip.py
+++ b/flask_monitoringdashboard/core/get_ip.py
@@ -1,0 +1,16 @@
+from flask import request
+
+from flask_monitoringdashboard import config
+from flask_monitoringdashboard.core.logger import log
+
+def get_ip():
+    """
+    :return: the ip address associated with the current request context
+    """
+    if config.get_ip:
+        try:
+            return config.get_ip()
+        except Exception as e:
+            log('Failed to execute provided get_ip function: {}'.format(e))
+    # This is a reasonable fallback, but will not work for clients behind proxies.
+    return request.environ['REMOTE_ADDR']

--- a/flask_monitoringdashboard/core/profiler/__init__.py
+++ b/flask_monitoringdashboard/core/profiler/__init__.py
@@ -1,7 +1,6 @@
 import threading
 
-from flask import request
-
+from flask_monitoringdashboard.core.get_ip import get_ip
 from flask_monitoringdashboard.core.group_by import get_group_by
 from flask_monitoringdashboard.core.profiler.base_profiler import BaseProfiler
 from flask_monitoringdashboard.core.profiler.outlier_profiler import OutlierProfiler
@@ -24,17 +23,15 @@ def start_performance_thread(endpoint, duration, status_code):
     :param duration: duration of the request
     :param status_code: HTTP status code of the request
     """
-    ip = request.environ['REMOTE_ADDR']
     group_by = get_group_by()
-    PerformanceProfiler(endpoint, ip, duration, group_by, status_code).start()
+    PerformanceProfiler(endpoint, get_ip(), duration, group_by, status_code).start()
 
 
 def start_profiler_thread(endpoint):
     """ Starts a thread that profiles the main thread. """
     current_thread = threading.current_thread().ident
-    ip = request.environ['REMOTE_ADDR']
     group_by = get_group_by()
-    thread = StacktraceProfiler(current_thread, endpoint, ip, group_by)
+    thread = StacktraceProfiler(current_thread, endpoint, get_ip(), group_by)
     thread.start()
     return thread
 
@@ -42,9 +39,8 @@ def start_profiler_thread(endpoint):
 def start_outlier_thread(endpoint):
     """ Starts a thread that collects outliers."""
     current_thread = threading.current_thread().ident
-    ip = request.environ['REMOTE_ADDR']
     group_by = get_group_by()
-    thread = OutlierProfiler(current_thread, endpoint, ip, group_by)
+    thread = OutlierProfiler(current_thread, endpoint, get_ip(), group_by)
     thread.start()
     return thread
 
@@ -52,7 +48,7 @@ def start_outlier_thread(endpoint):
 def start_profiler_and_outlier_thread(endpoint):
     """ Starts two threads: PerformanceProfiler and StacktraceProfiler.  """
     current_thread = threading.current_thread().ident
-    ip = request.environ['REMOTE_ADDR']
+    ip = get_ip()
     group_by = get_group_by()
     outlier = OutlierProfiler(current_thread, endpoint, ip, group_by)
     thread = StacktraceProfiler(current_thread, endpoint, ip, group_by, outlier)


### PR DESCRIPTION
This PR adds support for a custom IP address getter.

It is not correct to use `REMOTE_ADDR` in every case, though it is a reasonable fallback. We achieve this by introducing a function called `inject_dependencies` inside the `Config` class. This is going to be useful for future PRs because it opens the door for a few other things, such as:

* Overriding `url_for` usage in favor of some user-defined logic (In our case, we have an application using a multi-host configuration, so we don't define `SERVER_NAME` in our Flask configuration, and `url_for` does not do the right thing)
* Decoupling the authentication layer completely from FMD in favor of user-defined functions to determine if:
  * There is a logged in user
  * There is a logged in admin

Awaiting your feedback!