### PR TITLE
Soften up tzlocal requirement

### DIFF
--- a/requirements-micro.txt
+++ b/requirements-micro.txt
@@ -7,4 +7,4 @@ psutil                # for logging extra CPU-info
 colorhash             # for hashing a string into a color
 numpy                 # for computing median and other stats
 pytz                  # for timezone info
-tzlocal==2.0          # for figuring out the local timezone; frozen to 2.0 because 3.0 conflicts the latest version of appscheduler (as of jan.2020)
+tzlocal~=2.0          # for figuring out the local timezone; frozen to 2.0 because 3.0 conflicts the latest version of appscheduler (as of jan.2020)


### PR DESCRIPTION
Please don't merge this as-is, this is only an example. I have not fully tested this exact code change.

This requirement is causing some issues for me in a project which depends on a different version of tzlocal. As you write, it should be less than 3.0, but now is is strictly 2.0 exactly, which sounds too strict.