### PR TITLE
Use Blueprint.record_once instead of Blueprint.before_app_first_request

### DIFF
--- a/flask_monitoringdashboard/__init__.py
+++ b/flask_monitoringdashboard/__init__.py
@@ -64,8 +64,8 @@ def bind(app, schedule=True, include_dashboard=True):
     from flask_monitoringdashboard.core.cache import init_cache
     from flask_monitoringdashboard.core import custom_graph
 
-    blueprint.before_app_first_request(init_measurement)
-    blueprint.before_app_first_request(init_cache)
+    blueprint.record_once(lambda _state: init_measurement())
+    blueprint.record_once(lambda _state: init_cache())
     if schedule:
         custom_graph.init(app)
 


### PR DESCRIPTION
The Blueprint decorator method `before_app_first_request` is [deprecated](https://flask.palletsprojects.com/en/2.2.x/api/#flask.Blueprint.before_app_first_request) and will be removed in Flask 2.3. Instead, setup code should use the `record_once` decorator method. The functions wrapped with this decorator will be called when the blueprint is registered on an application instead of before the first request.