### PR TITLE
Avoid deprecated import of declarative_base from sqlalchemy.ext.declarative

### DIFF
--- a/flask_monitoringdashboard/database/__init__.py
+++ b/flask_monitoringdashboard/database/__init__.py
@@ -19,7 +19,12 @@ from sqlalchemy import (
     exc,
 )
 
-from sqlalchemy.ext.declarative import declarative_base
+try:
+    # the declarative API is a part of the ORM layer since SQLAlchemy 1.4
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    # however it used to be an extension before SQLAlchemy 1.4
+    from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship, scoped_session
 from werkzeug.security import generate_password_hash, check_password_hash
 


### PR DESCRIPTION
Originally, features like `declarative_base` were part of a SQLAlchemy extension. They were [moved to the `sqlalchemy.orm` package in SQLAlchemy 1.4](https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#change-5508) and since SQLAlchemy 2.0 using the old import from `sqlalchemy.ext.declarative` results in a warning:
```
[...]/flask_monitoringdashboard/database/__init__.py:28: MovedIn20Warning:

The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
```

This PR tries to import `declarative_base` from `sqlalchemy.orm` and, if that fails, falls back to `sqlalchemy.ext.declarative` for compatibility with SQLAlchemy versions older than 1.4.