### PR TITLE
Increase User.password_hash column size

### DIFF
--- a/flask_monitoringdashboard/database/__init__.py
+++ b/flask_monitoringdashboard/database/__init__.py
@@ -44,7 +44,7 @@ class User(Base):
     username = Column(String(250), unique=True, nullable=False)
     """Username for logging into the FMD."""
 
-    password_hash = Column(String(128), nullable=False)
+    password_hash = Column(String(162), nullable=False)
     """Hashed password."""
 
     is_admin = Column(Boolean, default=False)


### PR DESCRIPTION
Increases the User.password_hash column size to 162. This accommodates a recent werkzeug.security update to generate_password_hash, which moved to scrypt and defaults to 16 for the salt length.

Additional details may be found in #449. 