### PR TITLE
Specifies int type for endpoint_id get params in routes

### DIFF
--- a/flask_monitoringdashboard/views/endpoint.py
+++ b/flask_monitoringdashboard/views/endpoint.py
@@ -38,7 +38,7 @@ def get_overview():
         return jsonify(get_endpoint_overview(session))
 
 
-@blueprint.route('/api/users/<endpoint_id>')
+@blueprint.route('/api/users/<int:endpoint_id>')
 @secure
 def users(endpoint_id):
     """
@@ -54,7 +54,7 @@ def users(endpoint_id):
         return jsonify(dicts)
 
 
-@blueprint.route('/api/ip/<endpoint_id>')
+@blueprint.route('/api/ip/<int:endpoint_id>')
 @secure
 def ips(endpoint_id):
     """
@@ -135,7 +135,7 @@ def set_rule():
     return 'OK'
 
 
-@blueprint.route('/api/endpoint_info/<endpoint_id>')
+@blueprint.route('/api/endpoint_info/<int:endpoint_id>')
 @secure
 def endpoint_info(endpoint_id):
     """
@@ -154,7 +154,7 @@ def endpoint_info(endpoint_id):
         return jsonify(get_endpoint_details(session, endpoint_id))
 
 
-@blueprint.route('api/endpoint_status_code_distribution/<endpoint_id>')
+@blueprint.route('api/endpoint_status_code_distribution/<int:endpoint_id>')
 @secure
 def endpoint_status_code_distribution(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'endpoint_status_code_distribution/{endpoint_id}'})
@@ -162,7 +162,7 @@ def endpoint_status_code_distribution(endpoint_id):
         return jsonify(get_status_code_distribution(session, endpoint_id))
 
 
-@blueprint.route('api/endpoint_status_code_summary/<endpoint_id>')
+@blueprint.route('api/endpoint_status_code_summary/<int:endpoint_id>')
 @secure
 def endpoint_status_code_summary(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'endpoint_status_code_summary/{endpoint_id}'})
@@ -176,7 +176,7 @@ def endpoint_status_code_summary(endpoint_id):
         return jsonify(result)
 
 
-@blueprint.route('api/endpoint_versions/<endpoint_id>', methods=['POST'])
+@blueprint.route('api/endpoint_versions/<int:endpoint_id>', methods=['POST'])
 @secure
 def endpoint_versions(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'endpoint_versions/{endpoint_id}'})
@@ -186,7 +186,7 @@ def endpoint_versions(endpoint_id):
         return jsonify(get_endpoint_versions(session, endpoint_id, versions))
 
 
-@blueprint.route('/api/endpoint_users/<endpoint_id>', methods=['POST'])
+@blueprint.route('/api/endpoint_users/<int:endpoint_id>', methods=['POST'])
 @secure
 def endpoint_users(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'endpoint_users/{endpoint_id}'})

--- a/flask_monitoringdashboard/views/outlier.py
+++ b/flask_monitoringdashboard/views/outlier.py
@@ -10,7 +10,7 @@ from flask_monitoringdashboard.core.telemetry import post_to_back_if_telemetry_e
 from flask_monitoringdashboard import blueprint
 
 
-@blueprint.route('/api/num_outliers/<endpoint_id>')
+@blueprint.route('/api/num_outliers/<int:endpoint_id>')
 @secure
 def num_outliers(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'num_outliers/{endpoint_id}'})
@@ -18,7 +18,7 @@ def num_outliers(endpoint_id):
         return jsonify(count_outliers(session, endpoint_id))
 
 
-@blueprint.route('/api/outlier_graph/<endpoint_id>')
+@blueprint.route('/api/outlier_graph/<int:endpoint_id>')
 @secure
 def outlier_graph(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'outlier_graph/{endpoint_id}'})
@@ -26,7 +26,7 @@ def outlier_graph(endpoint_id):
         return jsonify(get_outlier_graph(session, endpoint_id))
 
 
-@blueprint.route('/api/outlier_table/<endpoint_id>/<offset>/<per_page>')
+@blueprint.route('/api/outlier_table/<int:endpoint_id>/<offset>/<per_page>')
 @secure
 def outlier_table(endpoint_id, offset, per_page):
     post_to_back_if_telemetry_enabled(**{'name': f'outlier_table/{endpoint_id}'})

--- a/flask_monitoringdashboard/views/profiler.py
+++ b/flask_monitoringdashboard/views/profiler.py
@@ -10,7 +10,7 @@ from flask_monitoringdashboard import blueprint
 from flask_monitoringdashboard.database.count import count_profiled_requests
 
 
-@blueprint.route('/api/num_profiled/<endpoint_id>')
+@blueprint.route('/api/num_profiled/<int:endpoint_id>')
 @secure
 def num_profiled(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'num_profiled/{endpoint_id}'})
@@ -18,7 +18,7 @@ def num_profiled(endpoint_id):
         return jsonify(count_profiled_requests(session, endpoint_id))
 
 
-@blueprint.route('/api/profiler_table/<endpoint_id>/<offset>/<per_page>')
+@blueprint.route('/api/profiler_table/<int:endpoint_id>/<offset>/<per_page>')
 @secure
 def profiler_table(endpoint_id, offset, per_page):
     post_to_back_if_telemetry_enabled(**{'name': f'profiled_table/{endpoint_id}'})
@@ -26,7 +26,7 @@ def profiler_table(endpoint_id, offset, per_page):
         return jsonify(get_profiler_table(session, endpoint_id, offset, per_page))
 
 
-@blueprint.route('/api/grouped_profiler/<endpoint_id>')
+@blueprint.route('/api/grouped_profiler/<int:endpoint_id>')
 @secure
 def grouped_profiler(endpoint_id):
     post_to_back_if_telemetry_enabled(**{'name': f'grouped_profiler/{endpoint_id}'})

--- a/flask_monitoringdashboard/views/request.py
+++ b/flask_monitoringdashboard/views/request.py
@@ -31,7 +31,7 @@ def num_requests(start_date, end_date):
 
 
 @blueprint.route('/api/hourly_load/<start_date>/<end_date>')
-@blueprint.route('/api/hourly_load/<start_date>/<end_date>/<endpoint_id>')
+@blueprint.route('/api/hourly_load/<start_date>/<end_date>/<int:endpoint_id>')
 @secure
 # both days must be in the form: yyyy-mm-dd
 def hourly_load(start_date, end_date, endpoint_id=None):

--- a/flask_monitoringdashboard/views/version.py
+++ b/flask_monitoringdashboard/views/version.py
@@ -15,7 +15,7 @@ from flask_monitoringdashboard.database.versions import get_versions
 
 
 @blueprint.route('/api/versions')
-@blueprint.route('/api/versions/<endpoint_id>')
+@blueprint.route('/api/versions/<int:endpoint_id>')
 @secure
 def versions(endpoint_id=None):
     """
@@ -56,7 +56,7 @@ def multi_version():
         return jsonify(get_multi_version_data(session, endpoints, versions))
 
 
-@blueprint.route('/api/version_user/<endpoint_id>', methods=['POST'])
+@blueprint.route('/api/version_user/<int:endpoint_id>', methods=['POST'])
 @secure
 def version_user(endpoint_id):
     """
@@ -87,7 +87,7 @@ def version_user(endpoint_id):
         return jsonify(get_version_user_data(session, endpoint_id, versions, users))
 
 
-@blueprint.route('/api/version_ip/<endpoint_id>', methods=['POST'])
+@blueprint.route('/api/version_ip/<int:endpoint_id>', methods=['POST'])
 @secure
 def version_ip(endpoint_id):
     """


### PR DESCRIPTION
These changes ensure endpoint_id is of type int when passed as a GET parameter. For full details, please see issue #451.