### PR TITLE
Fix status code incorrect when abort() function is used

### DIFF
--- a/flask_monitoringdashboard/core/measurement.py
+++ b/flask_monitoringdashboard/core/measurement.py
@@ -4,6 +4,7 @@
 """
 import time
 from functools import wraps
+from werkzeug.exceptions import HTTPException
 
 from flask_monitoringdashboard import config
 from flask_monitoringdashboard.core.profiler import (
@@ -108,7 +109,8 @@ def evaluate(route_handler, args, kwargs):
         status_code = status_code_from_response(result)
 
         return result, status_code, None
-
+    except HTTPException as e:
+        return None, e.code, e
     except Exception as e:
         return None, 500, e
 


### PR DESCRIPTION
When a user calls the `abort(400)` function, the Flask monitoring dashboard mistakenly records a status code of 500 instead of the expected 400.

```py
from flask import abort

@app.route('/search', methods=['GET'])
def search():
    abort(400)  # <- raise HTTPException
```

The underlying issue is that the `HTTPException` is being caught as a generic `Exception`, which is then incorrectly returned as a 500 error.

This pull request addresses and resolves this issue.

For more information on the Flask `abort()` function:
https://flask.palletsprojects.com/en/2.3.x/errorhandling/#custom-error-pages

