### PR TITLE
Detailed exception info is now available

### DIFF
--- a/flask_monitoringdashboard/controllers/exceptions.py
+++ b/flask_monitoringdashboard/controllers/exceptions.py
@@ -1,4 +1,5 @@
-from flask_monitoringdashboard.database.exception_info import get_exceptions_with_timestamps
+from flask_monitoringdashboard.database.exception_info import get_exceptions_with_timestamps, get_exceptions_with_timestamps_and_stacktrace_id
+from flask_monitoringdashboard.database.full_stack_trace import get_code_from_stacktrace_id
 
 def get_exceptions_with_timestamp(session, offset, per_page):
     """
@@ -18,3 +19,21 @@ def get_exceptions_with_timestamp(session, offset, per_page):
         }
         for exception in get_exceptions_with_timestamps(session, offset, per_page)
     ]
+
+def get_detailed_exception_info(session, offset, per_page, endpoint_id):
+    return [
+        {
+            'type': exception.exception_type, 
+            'message': exception.exception_msg, 
+            'full_stacktrace': [ 
+                {
+                    'code': exnsline.code.code,
+                    'filename': exnsline.code.filename,
+                    'line_number': exnsline.code.line_number
+                }
+                for exnsline in get_code_from_stacktrace_id(session, exception.full_stack_trace_id)],
+            'latest_timestamp': exception.latest_timestamp,
+            'first_timestamp': exception.first_timestamp,
+            'count': exception.count
+        }
+        for exception in get_exceptions_with_timestamps_and_stacktrace_id(session, offset, per_page, endpoint_id)]

--- a/flask_monitoringdashboard/database/exception_info.py
+++ b/flask_monitoringdashboard/database/exception_info.py
@@ -3,7 +3,6 @@ Contains all functions that access an ExceptionInfo object.
 """
 from sqlalchemy import func, desc
 from flask_monitoringdashboard.database import ExceptionInfo, Request, Endpoint
-
 def get_exception_info(session, request_id: int):
     """
     Retrieve an ExceptionInfo record by request_id.
@@ -70,5 +69,40 @@ def get_exceptions_with_timestamps(session, offset, per_page):
         .limit(per_page)
         .all()
     )
-    session.expunge_all()
+    return result
+
+
+def get_exceptions_with_timestamps_and_stacktrace_id(session, offset, per_page, endpoint_id):
+    """
+    Gets the requests of an endpoint sorted by request time, together with the stack lines.
+    :param session: session for the database
+    :param endpoint_id: filter profiled requests on this endpoint
+    :param offset: number of items to skip
+    :param per_page: number of items to return
+    :return: A list of tuples. Each tuple contains:
+             - exception_type (str)
+             - exception_msg (str)
+             - endpoint name (str)
+             - latest_timestamp (datetime)
+             - first_timestamp (datetime)
+             - count (int) representing the number of occurrences.
+    """
+    result = (
+        session.query(
+            ExceptionInfo.exception_type,
+            ExceptionInfo.exception_msg,
+            ExceptionInfo.full_stack_trace_id,
+            func.max(Request.time_requested).label('latest_timestamp'),
+            func.min(Request.time_requested).label('first_timestamp'),
+            func.count(ExceptionInfo.request_id).label('count')
+        )
+        .join(Request, ExceptionInfo.request_id == Request.id)
+        .join(Endpoint, Request.endpoint_id == Endpoint.id)
+        .where(Endpoint.id == endpoint_id)
+        .group_by(ExceptionInfo.full_stack_trace_id)
+        .order_by(desc('latest_timestamp'))
+        .offset(offset)
+        .limit(per_page)
+        .all()
+    )
     return result

--- a/flask_monitoringdashboard/database/full_stack_trace.py
+++ b/flask_monitoringdashboard/database/full_stack_trace.py
@@ -1,4 +1,4 @@
-from flask_monitoringdashboard.database import FullStackTrace
+from flask_monitoringdashboard.database import CodeLine, ExceptionStackLine, FullStackTrace, code_line
 
 def get_stack_trace_by_hash(session, full_stack_trace):
     """
@@ -22,3 +22,18 @@ def add_full_stack_trace(session, full_stack_trace: str):
     session.flush()
 
     return result.id
+
+
+def get_code_from_stacktrace_id(session, stack_trace_id):
+    """
+    Gets all the code lines referred to by a stacktrace.
+    """
+    result = (
+        session.query(
+            ExceptionStackLine
+        )
+        .filter(ExceptionStackLine.stack_trace_id == stack_trace_id)
+        .order_by(ExceptionStackLine.position)
+        .all()
+    )
+    return result

--- a/flask_monitoringdashboard/views/exception.py
+++ b/flask_monitoringdashboard/views/exception.py
@@ -3,7 +3,7 @@ from flask import jsonify
 from flask_monitoringdashboard import blueprint
 from flask_monitoringdashboard.core.auth import secure
 
-from flask_monitoringdashboard.controllers.exceptions import get_exceptions_with_timestamp
+from flask_monitoringdashboard.controllers.exceptions import get_exceptions_with_timestamp, get_detailed_exception_info
 from flask_monitoringdashboard.core.telemetry import post_to_back_if_telemetry_enabled
 from flask_monitoringdashboard.database import session_scope
 
@@ -29,3 +29,18 @@ def num_exceptions():
     post_to_back_if_telemetry_enabled(**{'name': f'num_exceptions'})
     with session_scope() as session:
         return jsonify(count_grouped_exceptions(session))
+
+@blueprint.route('/api/detailed_exception_info/<endpoint_id>/<offset>/<per_page>')
+@secure
+def get_detailed_exception_info_endpoint(endpoint_id, offset, per_page):
+    """
+    Get information about all the exceptions that have occured for a specific endpoint
+    :return: A JSON-list with a JSON-object per traceback id
+    """
+    post_to_back_if_telemetry_enabled(**{'name': 'detailed_exception_info'})
+    with session_scope() as session:
+        exceptions = get_detailed_exception_info(session, offset, per_page, endpoint_id)
+        
+        return jsonify(exceptions)
+ 
+


### PR DESCRIPTION
It is now possible to get detailed exception information on a specific endpoint, this means the usual exception info, but with an added stack trace such that it is visible where the exception occurred.