### PR TITLE
Feature/exn frontend detailed

### DIFF
--- a/flask_monitoringdashboard/controllers/exceptions.py
+++ b/flask_monitoringdashboard/controllers/exceptions.py
@@ -13,6 +13,7 @@ def get_exceptions_with_timestamp(session, offset, per_page):
             'type': exception.exception_type, 
             'message': exception.exception_msg, 
             'endpoint': exception.name,
+            'endpoint_id': exception.id,
             'latest_timestamp': exception.latest_timestamp,
             'first_timestamp': exception.first_timestamp,
             'count': exception.count

--- a/flask_monitoringdashboard/controllers/exceptions.py
+++ b/flask_monitoringdashboard/controllers/exceptions.py
@@ -29,7 +29,8 @@ def get_detailed_exception_info(session, offset, per_page, endpoint_id):
                 {
                     'code': exceptionStackLine.code.code,
                     'filename': exceptionStackLine.code.filename,
-                    'line_number': exceptionStackLine.code.line_number
+                    'line_number': exceptionStackLine.code.line_number,
+                    'function_name': exceptionStackLine.code.function_name
                 }
                 for exceptionStackLine in get_code_from_stacktrace_id(session, exception.full_stack_trace_id)],
             'latest_timestamp': exception.latest_timestamp,

--- a/flask_monitoringdashboard/core/exception_logger.py
+++ b/flask_monitoringdashboard/core/exception_logger.py
@@ -3,6 +3,7 @@ import linecache
 import hashlib
 
 from types import TracebackType
+from flask_monitoringdashboard import config
 from flask_monitoringdashboard.database import CodeLine
 from flask_monitoringdashboard.database.exception_info import add_exception_info
 from flask_monitoringdashboard.database.full_stack_trace import add_full_stack_trace, get_stack_trace_by_hash
@@ -10,10 +11,10 @@ from flask_monitoringdashboard.database.exception_stack_line import add_exceptio
 
 def create_codeline(fs: traceback.FrameSummary):
     c_line = CodeLine()
-    c_line.filename = fs.filename
+    c_line.filename = fs.filename.replace(config.app.root_path, '.')
     c_line.line_number = fs.lineno
     c_line.function_name = fs.name
-    c_line.code = linecache.getline(c_line.filename, c_line.line_number).strip()
+    c_line.code = linecache.getline(fs.filename, fs.lineno).strip()
     return c_line
 
 def hash_stack_trace(self):

--- a/flask_monitoringdashboard/core/exception_logger.py
+++ b/flask_monitoringdashboard/core/exception_logger.py
@@ -3,7 +3,7 @@ import linecache
 import hashlib
 
 from types import TracebackType
-from flask_monitoringdashboard import config
+#from flask_monitoringdashboard import config
 from flask_monitoringdashboard.database import CodeLine
 from flask_monitoringdashboard.database.exception_info import add_exception_info
 from flask_monitoringdashboard.database.full_stack_trace import add_full_stack_trace, get_stack_trace_by_hash
@@ -11,7 +11,8 @@ from flask_monitoringdashboard.database.exception_stack_line import add_exceptio
 
 def create_codeline(fs: traceback.FrameSummary):
     c_line = CodeLine()
-    c_line.filename = fs.filename.replace(config.app.root_path, '.')
+    #c_line.filename = fs.filename.replace(config.app.root_path, '.')
+    c_line.filename = fs.filename
     c_line.line_number = fs.lineno
     c_line.function_name = fs.name
     c_line.code = linecache.getline(fs.filename, fs.lineno).strip()

--- a/flask_monitoringdashboard/database/exception_info.py
+++ b/flask_monitoringdashboard/database/exception_info.py
@@ -63,6 +63,7 @@ def get_exceptions_with_timestamps(session, offset, per_page):
              - exception_type (str)
              - exception_msg (str)
              - endpoint name (str)
+             - endpoint id (int)
              - latest_timestamp (datetime)
              - first_timestamp (datetime)
              - count (int) representing the number of occurrences.
@@ -72,6 +73,7 @@ def get_exceptions_with_timestamps(session, offset, per_page):
             ExceptionInfo.exception_type,
             ExceptionInfo.exception_msg,
             Endpoint.name,
+            Endpoint.id,
             func.max(Request.time_requested).label('latest_timestamp'),
             func.min(Request.time_requested).label('first_timestamp'),
             func.count(ExceptionInfo.request_id).label('count')

--- a/flask_monitoringdashboard/database/exception_info.py
+++ b/flask_monitoringdashboard/database/exception_info.py
@@ -36,6 +36,21 @@ def count_grouped_exceptions(session):
         .group_by(Endpoint.name, ExceptionInfo.full_stack_trace_id)
         .count()
     )
+    
+def count_endpoint_grouped_exceptions(session, endpoint_id):
+    """
+    Count the number of different exceptions grouped by endpoint and full stack trace.
+    :param session: session for the database
+    :return: Integer (total number of grouped exceptions)
+    """
+    return (
+        session.query(ExceptionInfo.request_id)
+        .join(Request, ExceptionInfo.request_id == Request.id)
+        .join(Endpoint, Request.endpoint_id == Endpoint.id)
+        .filter(Endpoint.id == endpoint_id)
+        .group_by(Endpoint.name, ExceptionInfo.full_stack_trace_id)
+        .count()
+    )
 
 def get_exceptions_with_timestamps(session, offset, per_page):
     """

--- a/flask_monitoringdashboard/frontend/js/controllers/endpointException.js
+++ b/flask_monitoringdashboard/frontend/js/controllers/endpointException.js
@@ -10,7 +10,7 @@ export function EndpointExceptionController ($scope, $http, menuService, paginat
     });
 
     paginationService.onReload = function () {
-        $http.get('api/exception_info/' + paginationService.getLeft() + '/' + paginationService.perPage).then(function (response) {
+        $http.get('api/detailed_exception_info/' + endpointService.info.id + '/' + paginationService.getLeft() + '/' + paginationService.perPage).then(function (response) {
             $scope.table = response.data;
         });
     };

--- a/flask_monitoringdashboard/frontend/js/controllers/endpointException.js
+++ b/flask_monitoringdashboard/frontend/js/controllers/endpointException.js
@@ -5,7 +5,7 @@ export function EndpointExceptionController ($scope, $http, menuService, paginat
     $scope.table = [];
 
     paginationService.init('exceptions');
-    $http.get('api/num_exceptions').then(function (response) {
+    $http.get('api/num_exceptions/'+ endpointService.info.id).then(function (response) {
         paginationService.setTotal(response.data);
     });
 

--- a/flask_monitoringdashboard/static/pages/exception_stack_trace.html
+++ b/flask_monitoringdashboard/static/pages/exception_stack_trace.html
@@ -1,26 +1,41 @@
 <div class="card mb-3">
     <div class="card-header"><h4>Exceptions for this endpoint</h4></div>
     <div class="card-body">
-        <table class="table">
-            <thead>
-            <tr>
-                <th>Last seen</th>
-                <th>First occurence</th>
-                <th>Type</th>
-                <th>Message</th>
-                <th>Count</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr ng-repeat="row in table track by $index">
-                <td>{{ row.latest_timestamp | dateDifference }}</td>
-                <td>{{ row.first_timestamp | dateDifference }}</td>
-                <td>{{ row.type }}</td>
-                <td>{{ row.message }}</td>
-                <td>{{ row.count }}</td>
-            </tr>
-            </tbody>
-        </table>
+        <pagination></pagination>
+        <div class="card" ng-repeat="request in table" style="margin-bottom: 10px;">
+            <div class="card-header">
+                <div class="row align-items-end">
+                    <div class="col-sm"><h6>{{ request.type }}</h6></div>
+                    <div class="col-sm"><h6>Latest occurence: {{ request.latest_timestamp | dateDifference }}</h6></div>
+                </div>
+                <div class="row align-items-end">
+                    <div class="col-sm"><h6>{{ request.message }}</h6></div>
+                    <div class="col-sm"><h6>First occurence: {{ request.first_timestamp | dateDifference }}</h6></div>
+                </div>
+            </div>
+            <table class="table table-bordered table-hover" width="100%" style="margin: 0;" cellspacing="0">
+                <thead>
+                <tr>
+                    <th style="width: 30%">File name</th>
+                    <th style="width: 30%">Line number</th>
+                    <th style="width: 30%">Code-line</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr ng-repeat="row in request.full_stacktrace">
+                    <td style="padding-left: 10px;">
+                        {{ row.filename }}
+                    </td>
+                    <td style="padding-left: 10px;">
+                        {{ row.line_number }}
+                    </td>
+                    <td style="padding-left: 10px;">
+                        {{ row.code }}
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
         <pagination></pagination>
     </div>
     <endpointdetails></endpointdetails>

--- a/flask_monitoringdashboard/static/pages/exception_stack_trace.html
+++ b/flask_monitoringdashboard/static/pages/exception_stack_trace.html
@@ -17,17 +17,13 @@
                 <thead>
                 <tr>
                     <th style="width: 30%">File name</th>
-                    <th style="width: 30%">Line number</th>
                     <th style="width: 30%">Code-line</th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr ng-repeat="row in request.full_stacktrace">
                     <td style="padding-left: 10px;">
-                        {{ row.filename }}
-                    </td>
-                    <td style="padding-left: 10px;">
-                        {{ row.line_number }}
+                        {{ row.filename }} <span style="color: grey;">in</span> {{ row.function_name }} <span style="color: grey;">at</span> {{ row.line_number }}
                     </td>
                     <td style="padding-left: 10px;">
                         {{ row.code }}

--- a/flask_monitoringdashboard/static/pages/exception_stack_trace.html
+++ b/flask_monitoringdashboard/static/pages/exception_stack_trace.html
@@ -6,11 +6,11 @@
             <div class="card-header">
                 <div class="row align-items-end">
                     <div class="col-sm"><h6>{{ request.type }}</h6></div>
-                    <div class="col-sm"><h6>Latest occurence: {{ request.latest_timestamp | dateDifference }}</h6></div>
+                    <div class="col-sm"><h6>Number of occurences: {{ request.count }}</h6></div>
                 </div>
                 <div class="row align-items-end">
                     <div class="col-sm"><h6>{{ request.message }}</h6></div>
-                    <div class="col-sm"><h6>First occurence: {{ request.first_timestamp | dateDifference }}</h6></div>
+                    <div class="col-sm"><h6>Latest: {{ request.latest_timestamp | dateDifference }} | First: {{ request.first_timestamp | dateDifference }}</h6></div>
                 </div>
             </div>
             <table class="table table-bordered table-hover" width="100%" style="margin: 0;" cellspacing="0">

--- a/flask_monitoringdashboard/static/pages/new_dashboard.html
+++ b/flask_monitoringdashboard/static/pages/new_dashboard.html
@@ -16,7 +16,7 @@
             <tr ng-repeat="row in table track by $index">
                 <td>{{ row.latest_timestamp | dateDifference }}</td>
                 <td>{{ row.first_timestamp | dateDifference }}</td>
-                <td>{{ row.endpoint }}</td>
+                <td><a href="endpoint/{{ row.endpoint_id }}/exceptions">{{ row.endpoint }}</a></td>
                 <td>{{ row.type }}</td>
                 <td>{{ row.message }}</td>
                 <td>{{ row.count }}</td>

--- a/flask_monitoringdashboard/views/exception.py
+++ b/flask_monitoringdashboard/views/exception.py
@@ -7,7 +7,7 @@ from flask_monitoringdashboard.controllers.exceptions import get_exceptions_with
 from flask_monitoringdashboard.core.telemetry import post_to_back_if_telemetry_enabled
 from flask_monitoringdashboard.database import session_scope
 
-from flask_monitoringdashboard.database.exception_info import count_grouped_exceptions
+from flask_monitoringdashboard.database.exception_info import count_grouped_exceptions, count_endpoint_grouped_exceptions
 
 
 @blueprint.route('/api/exception_info/<offset>/<per_page>')
@@ -29,6 +29,13 @@ def num_exceptions():
     post_to_back_if_telemetry_enabled(**{'name': f'num_exceptions'})
     with session_scope() as session:
         return jsonify(count_grouped_exceptions(session))
+    
+@blueprint.route('/api/num_exceptions/<int:endpoint_id>')
+@secure
+def num_endpoint_exceptions(endpoint_id):
+    post_to_back_if_telemetry_enabled(**{'name': f'num_endpoint_exceptions'})
+    with session_scope() as session:
+        return jsonify(count_endpoint_grouped_exceptions(session, endpoint_id))
 
 @blueprint.route('/api/detailed_exception_info/<int:endpoint_id>/<offset>/<per_page>')
 @secure


### PR DESCRIPTION
Create new endpoint specific exception page where the exceptions occurring on a specific endpoint are displayed with information about type of exception, message, how many occurrences, latest/first occurrence and the traceback. 
We link to the endpoint specific exception page from the exceptions displayed on the general exception dashboard. 

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/93219778-d8e5-4d7a-924d-9d412fb2fa12" />

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/3823f0a5-2e47-44ea-8ae6-54ee01a8f4f7" />
