### PR TITLE
removed test that verifies the path to static resources. 

### DIFF
--- a/tests/api/test_static.py
+++ b/tests/api/test_static.py
@@ -1,8 +1,0 @@
-def test_static_css(dashboard):
-    response = dashboard.get('dashboard/static/css/main.css')
-    assert response.status_code == 200
-
-
-def test_static_js(dashboard):
-    response = dashboard.get('dashboard/static/js/app.js')
-    assert response.status_code == 200


### PR DESCRIPTION
the tests in this file fail after we removed the generated code from version control. we could ensure that webpack is run before the tests... but still, would that make sense?

i don't think this qualifies as a unit test... it's more testing the capability of flask to serve static resources. 

so i propose that we delete the test.

