### PR TITLE
Feature/different exceptions for throws endpoint

### DIFF
--- a/flask_monitoringdashboard/core/exceptions/scoped_exception_logger.py
+++ b/flask_monitoringdashboard/core/exceptions/scoped_exception_logger.py
@@ -1,4 +1,5 @@
 from typing import Union
+import copy
 
 
 class ScopedExceptionLogger:
@@ -25,5 +26,17 @@ def _get_copy_of_exception(e: BaseException):
     Helper function to reraise the uncaught exception with its original traceback,
     The copy is made in order to preserve the original exception's stack trace
     """
-    if e is not None:
-        return e.__class__(*e.args).with_traceback(e.__traceback__)
+    if e is None:
+        return None
+
+    try:
+        new_exc = e.__class__(*e.args)
+    except Exception:
+        try:
+            new_exc = copy.deepcopy(e)
+        except Exception:
+            new_exc = e.__class__()
+
+    if e.__traceback__:
+        return new_exc.with_traceback(e.__traceback__)
+    return new_exc

--- a/flask_monitoringdashboard/main.py
+++ b/flask_monitoringdashboard/main.py
@@ -8,6 +8,7 @@ is attached to your flask application.
 """
 
 import time
+import json
 from random import random, randint
 
 from flask import Flask, redirect, url_for
@@ -85,13 +86,41 @@ def endpoint5():
     return "Ok"
 
 
-def a():
-    raise Exception("åhhh nej")
+def reraised_and_captured_exception():
+    try:
+        raise Exception("åhhh nej")
+    except BaseException as e:
+        dashboard.capture(e)
+        try: 
+            e.args = (f"Reraised exception: {e.args[0]}",)
+            raise e
+        except BaseException as e2:
+            dashboard.capture(e2)
+            e.args = (f"Rereraised exception: {e.args[0]} (uncaught)",)
+            raise e2
+        
+def non_app_exception():
+    json.loads('{"invalid_json": }')
+
+def recursive_function(n):
+    if n == 0:
+        raise Exception("recursive åhhh nej")
+    elif n % 3 == 0:
+        return recursive_function(n - 2)
+    elif n % 3 == 1:
+        return recursive_function(n - 1)
+    else:
+        return recursive_function(n - 1)
 
 
 def b():
-    return a()
-
+    n = randint(1,3)
+    if n == 1:
+        return reraised_and_captured_exception()
+    if n == 2:
+        return non_app_exception()
+    if n == 3:
+        return recursive_function(100)
 
 def c():
     return b()


### PR DESCRIPTION
When saving a copy, there are different ways to do it, for json our current copy method did not work but deep copy worked

Three different exceptions are thrown for /throws endpoint (at random), each has a different purpose e.g showing difference between how non-app and in-app is displayed, and how recursion looks like in the UI.