### PR TITLE
Fix issue where users can neither accept nor deny telemetry

### DIFF
--- a/flask_monitoringdashboard/frontend/js/app.js
+++ b/flask_monitoringdashboard/frontend/js/app.js
@@ -89,7 +89,7 @@ app.controller('TelemetryController', ['$scope', '$http', '$window', TelemetryCo
 
 app.component('telemetryComponent', {
     templateUrl: 'static/pages/telemetry.html',
-    controller: ['$scope', '$http', '$window', TelemetryController],
+    controller: 'TelemetryController'
 });
 
 app.config(['$locationProvider', '$routeProvider', function ($locationProvider, $routeProvider) {

--- a/flask_monitoringdashboard/frontend/js/app.js
+++ b/flask_monitoringdashboard/frontend/js/app.js
@@ -85,10 +85,11 @@ app.controller('FormController', ['$scope', 'formService', FormController]);
 app.controller('EndpointController', ['$scope', 'endpointService', EndpointController]);
 app.controller('PaginationController', ['$scope', 'paginationService', PaginationController]);
 app.controller('ModalController', ['$scope', '$window', '$browser', 'modalService', ModalController]);
+app.controller('TelemetryController', ['$scope', '$http', '$window', TelemetryController]);
 
 app.component('telemetryComponent', {
     templateUrl: 'static/pages/telemetry.html',
-    controller: TelemetryController
+    controller: ['$scope', '$http', '$window', TelemetryController],
 });
 
 app.config(['$locationProvider', '$routeProvider', function ($locationProvider, $routeProvider) {

--- a/flask_monitoringdashboard/frontend/js/controllers/configuration.js
+++ b/flask_monitoringdashboard/frontend/js/controllers/configuration.js
@@ -96,9 +96,9 @@ export function ConfigurationController($scope, $http, menuService, endpointServ
     $scope.telemetryConsent;
 
     $scope.fetchTelemetryConsent = function () {
-        $http.get('/dashboard/telemetry/get_is_telemetry_answered')
+        $http.get('/dashboard/telemetry/get_is_telemetry_accepted')
             .then(function (response) {
-                $scope.telemetryConsent = response.data.is_telemetry_answered.toString();;
+                $scope.telemetryConsent = response.data.is_telemetry_accepted.toString();;
             }, function (error) {
                 console.error('Error fetching telemetry consent:', error);
             });

--- a/flask_monitoringdashboard/frontend/js/controllers/telemetryController.js
+++ b/flask_monitoringdashboard/frontend/js/controllers/telemetryController.js
@@ -8,7 +8,7 @@ export function TelemetryController($scope, $http, $window) {
     $scope.followUpShow = false;
 
     // Function to fetch telemetry consent status from database 
-    $scope.fetchTelemetryConsent = function () {
+    $scope.fetchTelemetryAnswered = function () {
         $http.get(`/dashboard/telemetry/get_is_telemetry_answered`)
             .then(function (response) {
                 $scope.telemetryShow = !response.data.is_telemetry_answered;
@@ -16,7 +16,7 @@ export function TelemetryController($scope, $http, $window) {
                 console.error('Error fetching telemetry consent:', error);
             });
     };
-    $scope.fetchTelemetryConsent();
+    $scope.fetchTelemetryAnswered();
 
     // Function to handle user response to telemetry prompt
     $scope.handleTelemetry = function (consent) {

--- a/flask_monitoringdashboard/views/telemetry.py
+++ b/flask_monitoringdashboard/views/telemetry.py
@@ -35,6 +35,13 @@ def get_is_telemetry_answered():
         telemetry_user = get_telemetry_user(session)
         res = True if telemetry_user.monitoring_consent in (TelemetryConfig.REJECTED, TelemetryConfig.ACCEPTED) else False
         return {'is_telemetry_answered': res}
+    
+@blueprint.route('/telemetry/get_is_telemetry_accepted', methods=['GET'])
+def get_is_telemetry_accepted():
+    with session_scope() as session:
+        telemetry_user = get_telemetry_user(session)
+        res = True if telemetry_user.monitoring_consent == TelemetryConfig.ACCEPTED else False
+        return {'is_telemetry_accepted': res}
 
 @blueprint.route('/telemetry/submit_follow_up', methods=['POST'])
 def submit_follow_up():


### PR DESCRIPTION
Correctly initialize TelemtryController in app.js

There was only an endpoint for checking if telemetry data was "answered" whether yes or no.
Not an endpoint for checking if the answer was "accepted" or not, so if it said "agree" under '/dashboard/configuration' it just indicated that you had clicked either yes or no, but the mechanism for clicking "decline" still worked.

So fortunately nobody gave away telemetry data without consent