### PR TITLE
reuse the existing paginationService for overview page

### DIFF
--- a/flask_monitoringdashboard/frontend/js/app.js
+++ b/flask_monitoringdashboard/frontend/js/app.js
@@ -95,7 +95,7 @@ app.config(['$locationProvider', '$routeProvider', function ($locationProvider, 
     $routeProvider
         .when('/overview', {
             templateUrl: 'static/pages/overview.html',
-            controller: ['$scope', '$http', '$location', 'menuService', 'endpointService', OverviewController]
+            controller: ['$scope', '$http', '$location', 'menuService', 'paginationService', 'endpointService', OverviewController]
         })
         .when('/exception_overview', {
             templateUrl: 'static/pages/exception_overview.html',

--- a/flask_monitoringdashboard/static/pages/overview.html
+++ b/flask_monitoringdashboard/static/pages/overview.html
@@ -165,7 +165,7 @@
                         </thead>
 
                         <tbody>
-                        <tr ng-repeat="row in getFilteredItems() track by $index"
+                        <tr ng-repeat="row in getFilteredItemsForPage() track by $index"
                             style="cursor: pointer"
                             ng-click="go('/endpoint/' + row.id + '/hourly_load')">
 
@@ -209,24 +209,7 @@
                     </table>
                 </div>
             </div>
-
-            <div class="row">
-                <div class="col-md-12">
-                    <nav aria-label="Page navigation example" style="float: right">
-                        <ul class="pagination">
-                            <li ng-class="{'disabled': !canGoBack()}"
-                                class="page-item">
-                                <a class="page-link" href="#" ng-click="previousPage()">Previous</a>
-                            </li>
-
-                            <li ng-class="{'disabled': !canGoForward() }" class="page-item">
-                                <a class="page-link" href="#"
-                                   ng-click="nextPage()">Next</a>
-                            </li>
-                        </ul>
-                    </nav>
-                </div>
-            </div>
+            <pagination></pagination>
         </div>
     </div>
 


### PR DESCRIPTION
reuse the existing paginationService for overview page: 
- less code 
- users can now see what page they are at (especially useful if more than 3 pages)
- users are shown the total number of endpoints
- still has the same functionality otherwise

Before:
<img width="1274" alt="Skærmbillede 2025-05-21 kl  20 00 03" src="https://github.com/user-attachments/assets/2a7a2cd8-9473-4bb2-b359-0643bb87e339" />


Now:
<img width="1251" alt="Skærmbillede 2025-05-21 kl  19 57 10" src="https://github.com/user-attachments/assets/be3bf56e-08b4-4945-81c3-438304c31dc7" />

Still works with choosing the number of endpoints to show on each page:
<img width="1275" alt="Skærmbillede 2025-05-21 kl  19 58 16" src="https://github.com/user-attachments/assets/3954d951-bbea-41ad-85f8-634d755a3fab" />

Super useful for many pages:
<img width="316" alt="Skærmbillede 2025-05-21 kl  20 04 40" src="https://github.com/user-attachments/assets/c8631f43-1221-4d8c-9fbd-8993e046874d" />
