### PR TITLE
Fix UTC Timezone

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ author = constants['author']
 version = constants['version']
 
 release = version
-copyright = '{}, {}. Version {}'.format(datetime.datetime.utcnow().year, author, version)
+copyright = '{}, {}. Version {}'.format(datetime.datetime.now(datetime.UTC).year, author, version)
 
 # -- General configuration ---------------------------------------------------
 

--- a/flask_monitoringdashboard/controllers/endpoints.py
+++ b/flask_monitoringdashboard/controllers/endpoints.py
@@ -32,8 +32,8 @@ def get_endpoint_overview(session):
     :param session: session for the database
     :return: A list of properties for each endpoint that is found in the database
     """
-    week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
-    now_local = to_local_datetime(datetime.datetime.utcnow())
+    week_ago = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7)
+    now_local = to_local_datetime(datetime.datetime.now(datetime.UTC))
     today_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
     today_utc = to_utc_datetime(today_local)
 

--- a/flask_monitoringdashboard/core/cache.py
+++ b/flask_monitoringdashboard/core/cache.py
@@ -69,7 +69,7 @@ def update_last_requested_cache(endpoint_name):
     Use this instead of updating the last requested to the database.
     """
     global memory_cache
-    memory_cache.get(endpoint_name).set_last_requested(datetime.datetime.utcnow())
+    memory_cache.get(endpoint_name).set_last_requested(datetime.datetime.now(datetime.UTC))
 
 
 def update_duration_cache(endpoint_name, duration):
@@ -77,7 +77,7 @@ def update_duration_cache(endpoint_name, duration):
     Use this together with adding a request to the database.
     """
     global memory_cache
-    memory_cache.get(endpoint_name).set_last_requested(datetime.datetime.utcnow())
+    memory_cache.get(endpoint_name).set_last_requested(datetime.datetime.now(datetime.UTC))
     memory_cache.get(endpoint_name).set_duration(duration)
 
 

--- a/flask_monitoringdashboard/core/telemetry.py
+++ b/flask_monitoringdashboard/core/telemetry.py
@@ -87,7 +87,7 @@ def initialize_telemetry_session(session):
         else:
             telemetry_user = session.query(TelemetryUser).one()
             telemetry_user.times_initialized += 1
-            telemetry_user.last_initialized = datetime.datetime.utcnow()
+            telemetry_user.last_initialized = datetime.datetime.now(datetime.UTC)
             session.commit()
 
         # reset telemetry if declined in previous session

--- a/flask_monitoringdashboard/core/timezone.py
+++ b/flask_monitoringdashboard/core/timezone.py
@@ -10,7 +10,7 @@ def to_local_datetime(dt):
     from flask_monitoringdashboard import config
 
     if dt:
-        return dt + config.timezone.utcoffset(datetime.datetime.utcnow())
+        return dt + config.timezone.utcoffset(datetime.datetime.now(datetime.UTC))
     return None
 
 
@@ -23,5 +23,5 @@ def to_utc_datetime(dt):
     from flask_monitoringdashboard import config
 
     if dt:
-        return dt - config.timezone.utcoffset(datetime.datetime.utcnow())
+        return dt - config.timezone.utcoffset(datetime.datetime.now(datetime.UTC))
     return None

--- a/flask_monitoringdashboard/database/endpoint.py
+++ b/flask_monitoringdashboard/database/endpoint.py
@@ -150,7 +150,7 @@ def update_last_requested(session, endpoint_name, timestamp=None):
     :param endpoint_name: name of the endpoint
     :param timestamp: optional timestamp. If not given, timestamp is current time
     """
-    ts = timestamp if timestamp else datetime.datetime.utcnow()
+    ts = timestamp if timestamp else datetime.datetime.now(datetime.UTC)
     session.query(Endpoint).filter(Endpoint.name == endpoint_name).update(
         {Endpoint.last_requested: ts}
     )


### PR DESCRIPTION
datetime.datetime.utcnow() is deprecated in favor of datetime.datetime.now(datetime.UTC)


Fixed where this is referenced in the code.