### PR TITLE
Bugfix/sorting fails again

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Please note that the changes before version 1.10.0 have not been documented.
 
+v4.0.4
+----------
+Changed
+
+Natalie, Carmen, and Albert
+- Bugfix: the fixed sorting compared numbers as strings.
+
 v4.0.3
 ----------
 Changed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ v4.0.4
 Changed
 
 Natalie, Carmen, and Albert
-- Bugfix: the fixed sorting compared numbers as strings.
+- Bugfix: the "fixed" sorting from last version compared numbers as strings.
 
 v4.0.3
 ----------

--- a/flask_monitoringdashboard/constants.json
+++ b/flask_monitoringdashboard/constants.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.3",
+    "version": "4.0.4",
     "author": "The FMD Contributors",
     "email": "flask.monitoringdashboard@gmail.com"
 }

--- a/flask_monitoringdashboard/frontend/js/controllers/OverviewController.js
+++ b/flask_monitoringdashboard/frontend/js/controllers/OverviewController.js
@@ -37,7 +37,8 @@ export function OverviewController($scope, $http, $location, menuService, pagina
         if ($scope.sortBy === 'last-accessed') {
             return (Date.parse(a[$scope.sortBy]) || null) - (Date.parse(b[$scope.sortBy]) || null);
         }
-        return String(a[$scope.sortBy]).localeCompare(String(b[$scope.sortBy]));
+
+        return a[$scope.sortBy] - b[$scope.sortBy];
     }
 
     function descendingOrder(a, b){


### PR DESCRIPTION
Sorry my bad! I was exiting getting sorting to work on Chrome, but accidentally introduced a new error to the sorting. It sorted by comparing the numbers as strings..

I found the real reason why it did not work on chrome, and fixed it