### PR TITLE
fixing the TypeError: CircularDependencyError.__init__() missing 3 re…

### DIFF
--- a/flask_monitoringdashboard/core/exceptions/exception_collector.py
+++ b/flask_monitoringdashboard/core/exceptions/exception_collector.py
@@ -62,7 +62,8 @@ def _get_copy_of_exception(e: BaseException):
         try:
             new_exc = copy.deepcopy(e)
         except Exception:
-            new_exc = e.__class__()
+            # For exceptions that can't be instantiated without args, just return the original
+            return e
 
     if e.__traceback__:
         return new_exc.with_traceback(e.__traceback__)


### PR DESCRIPTION
trying to fix this error that I've got on the zeeguu server:

```
  [Thu Jul 03 10:04:15.873598 2025] [wsgi:error] [pid 22:tid 43] [remote 172.18.0.1:44302]   File 
  "/usr/local/lib/python3.12/site-packages/flask_monitoringdashboard/core/exceptions/exception_collector.py", line 65, in _get_copy_of_exception
  [Thu Jul 03 10:04:15.873605 2025] [wsgi:error] [pid 22:tid 43] [remote 172.18.0.1:44302]     new_exc = e.__class__()
  [Thu Jul 03 10:04:15.873609 2025] [wsgi:error] [pid 22:tid 43] [remote 172.18.0.1:44302]               ^^^^^^^^^^^^^
  [Thu Jul 03 10:04:15.873615 2025] [wsgi:error] [pid 22:tid 43] [remote 172.18.0.1:44302] TypeError: CircularDependencyError.__init__() missing 3 required positional arguments: 
  'message', 'cycles', and 'edges'

```