### PR TITLE
Fix requests dependency version conflict by unpinning version constraint

### DIFF
--- a/requirements-micro.txt
+++ b/requirements-micro.txt
@@ -7,5 +7,5 @@ psutil                # for logging extra CPU-info
 colorhash             # for hashing a string into a color
 numpy                 # for computing median and other stats
 pytz                  # for timezone info
-requests==2.32.4      # for telemetry data posting
+requests              # for telemetry data posting
 tzlocal==2.0          # for figuring out the local timezone; frozen to 2.0 because 3.0 conflicts the latest version of appscheduler (as of jan.2020)


### PR DESCRIPTION
Hello,

Thanks for the hard work done on Flask-MonitoringDashboard.

This pull request removes the pinned version constraint on the requests package to resolve recurring dependency conflicts in large projects. The current pinned version requests==2.32.4 creates compatibility issues when other packages in the ecosystem require newer versions of requests, leading to dependency resolution failures during updates.

By unpinning the requests version while maintaining the duplicate entry cleanup, this change allows for more flexible dependency management and reduces conflicts in complex project environments where multiple packages depend on different versions of the requests library.

The change maintains backward compatibility while enabling smoother integration with projects that have evolving dependency requirements.

Thank you 